### PR TITLE
Update fish_fillet.json

### DIFF
--- a/src/main/resources/data/pizzacraft/recipes/fish_fillet.json
+++ b/src/main/resources/data/pizzacraft/recipes/fish_fillet.json
@@ -6,7 +6,7 @@
   },
   "input":
   {
-    "tag": "forge:raw_fishes"
+    "tag": "forge:rawfish"
   },
   "result": {
     "item": "pizzacraft:fish_fillet",


### PR DESCRIPTION
Fixed the forge tag, it's rawfish, you likely could use fishes as well without the "raw_" prefix.  Also, you can change cooked_fishes to cookedfish to make fillet crafting easier.