### PR TITLE
Update SeedsLootModifier.java

### DIFF
--- a/src/main/java/com/tiviacz/pizzacraft/common/SeedsLootModifier.java
+++ b/src/main/java/com/tiviacz/pizzacraft/common/SeedsLootModifier.java
@@ -64,7 +64,7 @@ public class SeedsLootModifier extends LootModifier
         }
         if(PizzaCraftConfig.SERVER.tomatoSeedDrops.get())
         {
-            pool.add(ModItems.TOMATO.get().getDefaultInstance());
+            pool.add(ModItems.TOMATO_SEEDS.get().getDefaultInstance());
         }
         if(PizzaCraftConfig.SERVER.cornDrops.get())
         {


### PR DESCRIPTION
Fixed tomato seed drops, now drops the seeds instead of the crop itself.  Without a way to get tomato seeds, you can't farm tomatoes for sauce.